### PR TITLE
Fix for incorrect masking of bits.

### DIFF
--- a/i2c_temp/i2c_temp.ino
+++ b/i2c_temp/i2c_temp.ino
@@ -32,7 +32,7 @@ void loop() {
     humidity = 100.0 / pow(2,14) * rawHumidity;
     
     // combine temperature bytes and calculate temperature
-    b4 = (b4 &= 0x3F); //Mask away 2 least sign. bits see HYT 221 doc
+    b4 = (b4 >> 2); // Mask away 2 least significant bits see HYT 221 doc
     int rawTemperature = b3 << 6 | b4;
     temperature = 165.0 / pow(2,14) * rawTemperature - 40;
     


### PR DESCRIPTION
You are masking away the 2 most significant bits here, not the least significant ones. 

From the protocol description:
"The bits 15 to 2 represent the 14 bit measured value. Bit 1 and 0 are not used." 

```
MSB.................................LSB
|15|14|13|12|11|10|9|8|7|6|5|4|3|2|1|0|
```

You are instead removing bit 7 and 6, and still using bit 1 and 0.

Also note that writing:

```
b4 = (b4 &= 0x3f)
```

is equivalent to

```
b4 = (b4 = (b4 & 0x3f));
```

In this case it doesn't matter, but it's not wise to use &= where simply & is intended. The correct code would be either of these:

```
b4 = b4 & 0x3F;
b4 &= 0x3F;
```

P.S. Your description should give a link to the protocol documentation:
http://www.ist-ag.com/eh/ist-ag/resource.nsf/imgref/Download_AHHYT-I2C_E1.2.pdf/$FILE/AHHYT-I2C_E1.2.pdf

The stupid HYT221 product page doesn't list it under its download page so I had a hard time finding it: http://www.hygrochip.com/index.php?id=3833&L=1
